### PR TITLE
add default task to makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,8 @@
 SHELL := /bin/bash
+
+all:
+	make watch-sass render-jade start-browser-sync -j
+
 watch-sass:
 	sass --watch scss/main.scss:css/main.css
 render-jade:


### PR DESCRIPTION
Running `make` without options will run this. Now you can delete `run-dev-environment.sh`